### PR TITLE
Direct link to dictionaries.zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ $ sudo pip install Fuzzy
 
 **Name-Gender Dictionaries**
 
-The dictionaries can be found on [downloads page] (https://github.com/KartikTalwar/LeGenderary/downloads)
+The dictionaries can be [downloaded here](https://github.com/downloads/KartikTalwar/LeGenderary/dictionaries.zip)
 
 ## Methods
 


### PR DESCRIPTION
Github removed the downloads page years ago, but the uploaded files seem to still be there, if you know the exact name.

References:
- https://github.blog/2012-12-12-goodbye-uploads/
- https://web.archive.org/web/20200926055756/https://github.com/KartikTalwar/LeGenderary/downloads